### PR TITLE
Add preload option

### DIFF
--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -132,15 +132,21 @@ defmodule Canary.Plugs do
     |> Map.fetch(resource_name(conn, opts))
     |> case do
       :error ->
-        Application.get_env(:canary, :repo).get(opts[:model], conn.params["id"])
+        repo = Application.get_env(:canary, :repo)
+        repo.get(opts[:model], conn.params["id"])
+        |> repo.preload(opts[:preload])
       {:ok, nil} ->
-        Application.get_env(:canary, :repo).get(opts[:model], conn.params["id"])
+        repo = Application.get_env(:canary, :repo)
+        repo.get(opts[:model], conn.params["id"])
+        |> repo.preload(opts[:preload])
       {:ok, resource} -> # if there is already a resource loaded onto the conn
         case (resource.__struct__ == opts[:model]) do
           true  ->
             resource
           false ->
-            Application.get_env(:canary, :repo).get(opts[:model], conn.params["id"])
+            repo = Application.get_env(:canary, :repo)
+            repo.get(opts[:model], conn.params["id"])
+            |> repo.preload(opts[:preload])
         end
     end
   end
@@ -150,13 +156,15 @@ defmodule Canary.Plugs do
     |> Map.fetch(resource_name(conn, opts))
     |> case do
       :error ->
-        from(m in opts[:model]) |> select([m], m) |> Application.get_env(:canary, :repo).all
+        repo = Application.get_env(:canary, :repo)
+        from(m in opts[:model]) |> select([m], m) |> repo.get_env(:canary, :repo).all |> repo.preload(opts[:preload])
       {:ok, resource} ->
         case (resource.__struct__ == opts[:model]) do
           true  ->
             resource
           false ->
-            from(m in opts[:model]) |> select([m], m) |> Application.get_env(:canary, :repo).all
+            repo = Application.get_env(:canary, :repo)
+            from(m in opts[:model]) |> select([m], m) |> repo.get_env(:canary, :repo).all |> repo.preload(opts[:preload])
         end
     end
   end

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -157,14 +157,14 @@ defmodule Canary.Plugs do
     |> case do
       :error ->
         repo = Application.get_env(:canary, :repo)
-        from(m in opts[:model]) |> select([m], m) |> repo.get_env(:canary, :repo).all |> repo.preload(opts[:preload])
+        from(m in opts[:model]) |> select([m], m) |> repo.all |> repo.preload(opts[:preload])
       {:ok, resource} ->
         case (resource.__struct__ == opts[:model]) do
           true  ->
             resource
           false ->
             repo = Application.get_env(:canary, :repo)
-            from(m in opts[:model]) |> select([m], m) |> repo.get_env(:canary, :repo).all |> repo.preload(opts[:preload])
+            from(m in opts[:model]) |> select([m], m) |> repo.all |> repo.preload(opts[:preload])
         end
     end
   end

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -134,11 +134,11 @@ defmodule Canary.Plugs do
       :error ->
         repo = Application.get_env(:canary, :repo)
         repo.get(opts[:model], conn.params["id"])
-        |> repo.preload(opts[:preload])
+        |> preload_if_needed(repo, opts)
       {:ok, nil} ->
         repo = Application.get_env(:canary, :repo)
         repo.get(opts[:model], conn.params["id"])
-        |> repo.preload(opts[:preload])
+        |> preload_if_needed(repo, opts)
       {:ok, resource} -> # if there is already a resource loaded onto the conn
         case (resource.__struct__ == opts[:model]) do
           true  ->
@@ -146,7 +146,7 @@ defmodule Canary.Plugs do
           false ->
             repo = Application.get_env(:canary, :repo)
             repo.get(opts[:model], conn.params["id"])
-            |> repo.preload(opts[:preload])
+            |> preload_if_needed(repo, opts)
         end
     end
   end
@@ -157,14 +157,14 @@ defmodule Canary.Plugs do
     |> case do
       :error ->
         repo = Application.get_env(:canary, :repo)
-        from(m in opts[:model]) |> select([m], m) |> repo.all |> repo.preload(opts[:preload])
+        from(m in opts[:model]) |> select([m], m) |> repo.all |> preload_if_needed(repo, opts)
       {:ok, resource} ->
         case (resource.__struct__ == opts[:model]) do
           true  ->
             resource
           false ->
             repo = Application.get_env(:canary, :repo)
-            from(m in opts[:model]) |> select([m], m) |> repo.all |> repo.preload(opts[:preload])
+            from(m in opts[:model]) |> select([m], m) |> repo.all |> preload_if_needed(repo, opts)
         end
     end
   end
@@ -230,4 +230,14 @@ defmodule Canary.Plugs do
       _    -> name
     end
   end
+
+  defp preload_if_needed(records, repo, opts) do
+    case opts[:preload] do
+      nil ->
+        records
+      models ->
+        repo.preload(records, models)
+    end
+  end
+
 end

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -26,7 +26,6 @@ defmodule Repo do
   def preload(%Post{id: 2, user_id: 2}, :user), do: %Post{id: 2, user_id: 2, user: %User{id: 2}}
   def preload([%Post{id: 1},  %Post{id: 2, user_id: 2}], :user), do: [%Post{id: 1}, %Post{id: 2, user_id: 2, user: %User{id: 2}}]
   def preload(resources, _), do: resources
-
 end
 
 defimpl Canada.Can, for: User do
@@ -61,7 +60,7 @@ defmodule PlugTest do
 
   Application.put_env :canary, :repo, Repo
 
-  test "it loads the load resource correctly" do
+  test "it loads the resource correctly" do
     opts = [model: Post]
 
     # when the resource with the id can be fetched
@@ -664,7 +663,7 @@ defmodule PlugTest do
   defmodule Preload do
     use ExUnit.Case, async: true
   
-    test "it loads the load resource correctly when the :preload key is specified" do
+    test "it loads the resource correctly when the :preload key is specified" do
       opts = [model: Post, preload: :user]
 
       # when the resource with the id can be fetched and the association exists
@@ -675,7 +674,7 @@ defmodule PlugTest do
       assert load_resource(conn, opts) == expected
 
 
-      # when the resource with the id can be fetched and the association not exists
+      # when the resource with the id can be fetched and the association does not exists
       params = %{"id" => 1}
       conn = conn(%Plug.Conn{private: %{phoenix_action: :show}}, :get, "/posts/1", params)
       expected = %{conn | assigns: Map.put(conn.assigns, :post, %Post{id: 1, user_id: 1})}
@@ -765,7 +764,7 @@ defmodule PlugTest do
 
 
       # when the current user can access the given resource
-      # and the resource can be loaded and the association not exists
+      # and the resource can be loaded and the association does not exists
       params = %{"id" => 1}
       conn = conn(
         %Plug.Conn{
@@ -799,5 +798,4 @@ defmodule PlugTest do
       assert load_and_authorize_resource(conn, opts) == expected
     end
   end
-
 end

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -6,6 +6,8 @@ defmodule Post do
   use Ecto.Model
 
   schema "posts" do
+    belongs_to :user, :integer, define_field: false # :defaults not working so define own field with default value
+
     field :user_id, :integer, default: 1
   end
 end
@@ -18,10 +20,17 @@ defmodule Repo do
   def get(Post, 2), do: %Post{id: 2, user_id: 2 }
   def get(Post, _), do: nil
 
-  def all(_), do: [%Post{id: 1}, %Post{id: 2}]
+  def all(_), do: [%Post{id: 1}, %Post{id: 2, user_id: 2}]
+
+  def preload(%Post{id: 1}, :user), do: %Post{id: 1}
+  def preload(%Post{id: 2, user_id: 2}, :user), do: %Post{id: 2, user_id: 2, user: %User{id: 2}}
+  def preload([%Post{id: 1},  %Post{id: 2, user_id: 2}], :user), do: [%Post{id: 1}, %Post{id: 2, user_id: 2, user: %User{id: 2}}]
+  def preload(resources, _), do: resources
+
 end
 
 defimpl Canada.Can, for: User do
+
   def can?(%User{id: user_id}, action, %Post{user_id: user_id})
   when action in [:show], do: true
 
@@ -29,6 +38,9 @@ defimpl Canada.Can, for: User do
 
   def can?(%User{}, action, Post)
     when action in [:new, :create], do: true
+
+  def can?(%User{id: user_id}, action, %Post{user: %User{id: user_id}})
+    when action in [:edit, :update], do: true
 
   def can?(%User{}, _, _), do: false
 end
@@ -48,7 +60,6 @@ defmodule PlugTest do
   @moduletag timeout: 100000000
 
   Application.put_env :canary, :repo, Repo
-
 
   test "it loads the load resource correctly" do
     opts = [model: Post]
@@ -72,7 +83,7 @@ defmodule PlugTest do
     # when the action is "index"
     params = %{}
     conn = conn(%Plug.Conn{private: %{phoenix_action: :index}}, :get, "/posts", params)
-    expected = %{conn | assigns: Map.put(conn.assigns, :posts, [%Post{id: 1}, %Post{id: 2}])}
+    expected = %{conn | assigns: Map.put(conn.assigns, :posts, [%Post{id: 1}, %Post{id: 2, user_id: 2}])}
 
     assert load_resource(conn, opts) == expected
 
@@ -649,4 +660,144 @@ defmodule PlugTest do
       end
     end
   end
+
+  defmodule Preload do
+    use ExUnit.Case, async: true
+  
+    test "it loads the load resource correctly when the :preload key is specified" do
+      opts = [model: Post, preload: :user]
+
+      # when the resource with the id can be fetched and the association exists
+      params = %{"id" => 2}
+      conn = conn(%Plug.Conn{private: %{phoenix_action: :show}}, :get, "/posts/1", params)
+      expected = %{conn | assigns: Map.put(conn.assigns, :post, %Post{id: 2, user_id: 2, user: %User{id: 2}})}
+
+      assert load_resource(conn, opts) == expected
+
+
+      # when the resource with the id can be fetched and the association not exists
+      params = %{"id" => 1}
+      conn = conn(%Plug.Conn{private: %{phoenix_action: :show}}, :get, "/posts/1", params)
+      expected = %{conn | assigns: Map.put(conn.assigns, :post, %Post{id: 1, user_id: 1})}
+
+      assert load_resource(conn, opts) == expected
+
+
+      # when the resource with the id cannot be fetched
+      params = %{"id" => 3}
+      conn = conn(%Plug.Conn{private: %{phoenix_action: :show}}, :get, "/posts/3", params)
+      expected = %{conn | assigns: Map.put(conn.assigns, :post, nil)}
+
+      assert load_resource(conn, opts) == expected
+
+
+      # when the action is "index"
+      params = %{}
+      conn = conn(%Plug.Conn{private: %{phoenix_action: :index}}, :get, "/posts", params)
+      expected = %{conn | assigns: Map.put(conn.assigns, :posts, [%Post{id: 1}, %Post{id: 2, user_id: 2, user: %User{id: 2}}])}
+
+      assert load_resource(conn, opts) == expected
+
+
+      # when the action is "new"
+      params = %{}
+      conn = conn(%Plug.Conn{private: %{phoenix_action: :new}}, :get, "/posts/new", params)
+      expected = %{conn | assigns: Map.put(conn.assigns, :post, nil)}
+
+      assert load_resource(conn, opts) == expected
+    end
+
+    test "it authorizes the resource correctly when the :preload key is specified" do
+      opts = [model: Post, preload: :user]
+
+      # when the action is "edit"
+      # In this case we use the loaded association and check params of this one in can?/3
+      params = %{"id" => 2}
+      conn = conn(
+        %Plug.Conn{
+          private: %{phoenix_action: :edit},
+          assigns: %{current_user: %User{id: 2}}
+        },
+        :get,
+        "/posts/edit/2",
+        params
+      )
+      expected = %{conn | assigns: Map.put(conn.assigns, :authorized, true)}
+
+      assert authorize_resource(conn, opts) == expected
+
+
+      # when the action is "index"
+      params = %{}
+      conn = conn(
+        %Plug.Conn{
+          private: %{phoenix_action: :index},
+          assigns: %{current_user: %User{id: 1}}
+        },
+        :get,
+        "/posts",
+        params
+      )
+      expected = %{conn | assigns: Map.put(conn.assigns, :authorized, true)}
+
+      assert authorize_resource(conn, opts) == expected
+    end
+
+    test "it loads and authorizes the resource correctly when the :preload key is specified" do
+      opts = [model: Post, preload: :user]
+
+      # when the current user can access the given resource
+      # and the resource can be loaded and the association exists
+      params = %{"id" => 2}
+      conn = conn(
+        %Plug.Conn{
+          private: %{phoenix_action: :show},
+          assigns: %{current_user: %User{id: 2}}
+        },
+        :get,
+        "/posts/2",
+        params
+      )
+      expected = %{conn | assigns: Map.put(conn.assigns, :authorized, true)}
+      expected = %{expected | assigns: Map.put(expected.assigns, :post, %Post{id: 2, user_id: 2, user: %User{id: 2}})}
+
+      assert load_and_authorize_resource(conn, opts) == expected
+
+
+      # when the current user can access the given resource
+      # and the resource can be loaded and the association not exists
+      params = %{"id" => 1}
+      conn = conn(
+        %Plug.Conn{
+          private: %{phoenix_action: :show},
+          assigns: %{current_user: %User{id: 1}}
+        },
+        :get,
+        "/posts/1",
+        params
+      )
+      expected = %{conn | assigns: Map.put(conn.assigns, :authorized, true)}
+      expected = %{expected | assigns: Map.put(expected.assigns, :post, %Post{id: 1, user_id: 1})}
+
+      assert load_and_authorize_resource(conn, opts) == expected
+
+      # when the action is "edit"
+      # In this case we use the loaded association and check params of this one in can?/3
+      params = %{"id" => 2}
+      conn = conn(
+        %Plug.Conn{
+          private: %{phoenix_action: :edit},
+          assigns: %{current_user: %User{id: 2}}
+        },
+        :get,
+        "/posts/edit/2",
+        params
+      )
+      expected = %{conn | assigns: Map.put(conn.assigns, :authorized, true)}
+      expected = %{expected | assigns: Map.put(expected.assigns, :post, %Post{id: 2, user_id: 2, user: %User{id: 2}})}
+
+      assert load_and_authorize_resource(conn, opts) == expected
+    end
+  end
+
 end


### PR DESCRIPTION
Add option for preloading given associations.
That's helpfull for loading resources with related data and having more informations in the `can?` function.
