### PR TITLE
Namespace conn.assigns.action to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Checks whether or not the ```current_user``` can perform the given action on the
 
 For Phoenix applications, Canary determines the action automatically.
 
-For non-Phoenix applications, or to override the action provided by Phoenix, simply ensure that ```conn.assigns.action``` contains an atom specifying the action.
+For non-Phoenix applications, or to override the action provided by Phoenix, simply ensure that ```conn.assigns.canary_action``` contains an atom specifying the action.
 
 In order to authorize resources, you must specify permissions by implementing the [Canada.Can protocol](https://github.com/jarednorman/canada) for your ```User``` model (Canada is included as a light weight dependency).
 

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -262,7 +262,7 @@ defmodule Canary.Plugs do
 
   defp get_action(conn) do
     conn.assigns
-    |> Map.fetch(:action)
+    |> Map.fetch(:canary_action)
     |> case do
       {:ok, action} -> action
       _             -> conn.private.phoenix_action

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -176,7 +176,7 @@ defmodule PlugTest do
     conn = conn(
       %Plug.Conn{
         private: %{},
-        assigns: %{current_user: %User{id: 1}, action: :show}
+        assigns: %{current_user: %User{id: 1}, canary_action: :show}
       },
       :get,
       "/posts/1",
@@ -193,7 +193,7 @@ defmodule PlugTest do
     conn = conn(
       %Plug.Conn{
         private: %{phoenix_action: :show},
-        assigns: %{current_user: %User{id: 1}, action: :unauthorized}
+        assigns: %{current_user: %User{id: 1}, canary_action: :unauthorized}
       },
       :get,
       "/posts/1",
@@ -209,7 +209,7 @@ defmodule PlugTest do
     conn = conn(
       %Plug.Conn{
         private: %{},
-        assigns: %{current_user: %User{id: 1}, action: :show}
+        assigns: %{current_user: %User{id: 1}, canary_action: :show}
       },
       :get,
       "/posts/2",
@@ -225,7 +225,7 @@ defmodule PlugTest do
     conn = conn(
       %Plug.Conn{
         private: %{},
-        assigns: %{current_user: nil, action: :create}
+        assigns: %{current_user: nil, canary_action: :create}
       },
       :post,
       "/posts",
@@ -262,7 +262,7 @@ defmodule PlugTest do
     conn = conn(
       %Plug.Conn{
         private: %{},
-        assigns: %{current_user: %User{id: 1}, action: :show}
+        assigns: %{current_user: %User{id: 1}, canary_action: :show}
       },
       :get,
       "/posts/2",
@@ -279,7 +279,7 @@ defmodule PlugTest do
     conn = conn(
       %Plug.Conn{
         private: %{},
-        assigns: %{current_user: %User{id: 1}, action: :show}
+        assigns: %{current_user: %User{id: 1}, canary_action: :show}
       },
       :get,
       "/posts/1",


### PR DESCRIPTION
That is, conflict with unrelated resource assigned to .action.

Resolves https://github.com/cpjk/canary/issues/24
