### PR TITLE
extend model name actions in authorize_resource plug

### DIFF
--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -193,11 +193,12 @@ defmodule Canary.Plugs do
     current_user = Dict.fetch! conn.assigns, current_user_name
     action = get_action(conn)
     is_persisted = persisted?(opts)
+    non_id_actions = if opts[:non_id], do: ([:index, :new, :create] ++ opts[:non_id]), else: [:index, :new, :create]
 
     resource = cond do
       is_persisted ->
         fetch_resource(conn, opts)
-      action in [:index, :new, :create] ->
+      action in non_id_actions ->
         opts[:model]
       true ->
         fetch_resource(conn, opts)
@@ -431,9 +432,10 @@ defmodule Canary.Plugs do
 
   defp handle_not_found(conn, opts) do
     action = get_action(conn)
+    non_id_actions = if opts[:non_id], do: ([:index, :new, :create] ++ opts[:non_id]), else: [:index, :new, :create]
 
     case is_nil(Map.get(conn.assigns, resource_name(conn, opts)))
-      and not action in [:index, :new, :create] do
+      and not action in non_id_actions do
 
       true -> apply_error_handler(conn, :not_found_handler, opts)
       false -> conn

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -193,7 +193,7 @@ defmodule Canary.Plugs do
     current_user = Dict.fetch! conn.assigns, current_user_name
     action = get_action(conn)
     is_persisted = persisted?(opts)
-    non_id_actions = if opts[:non_id], do: ([:index, :new, :create] ++ opts[:non_id]), else: [:index, :new, :create]
+    non_id_actions = if opts[:non_id_actions], do: Enum.concat([:index, :new, :create], opts[:non_id_actions]), else: [:index, :new, :create]
 
     resource = cond do
       is_persisted ->
@@ -432,7 +432,7 @@ defmodule Canary.Plugs do
 
   defp handle_not_found(conn, opts) do
     action = get_action(conn)
-    non_id_actions = if opts[:non_id], do: ([:index, :new, :create] ++ opts[:non_id]), else: [:index, :new, :create]
+    non_id_actions = if opts[:non_id_actions], do: Enum.concat([:index, :new, :create], opts[:non_id_actions]), else: [:index, :new, :create]
 
     case is_nil(Map.get(conn.assigns, resource_name(conn, opts)))
       and not action in non_id_actions do


### PR DESCRIPTION
PR to extend non-id actions ie those that require model name as opposed to struct; list is currently hard-coded to [:index, :new, :create].
Actions are specified using 'non_id' option on authorize_resource plug. e.g, non_id: [:action1, :custom_action2, ...].
Note that this also addresses issue #38 on authorizing singleton resources.
