### PR TITLE
Added loaded resource from model id to conn.assigns

### DIFF
--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -205,9 +205,11 @@ defmodule Canary.Plugs do
 
     case current_user |> can?(action, resource) do
       true  ->
-        %{conn | assigns: Map.put(conn.assigns, :authorized, true)}
+        conn
+        |> Plug.Conn.assign(:authorized, true)
+        |> Plug.Conn.assign(:request_resource, resource)
       false ->
-        %{conn | assigns: Map.put(conn.assigns, :authorized, false)}
+        Plug.Conn.assign(conn, :authorized, false)
     end
   end
 


### PR DESCRIPTION
Since might be necessary a loaded resource from the model id, I think it should be added to conn.assigns.

The problem is that, using Guardian, there is already a current_user from the jwt. But you cannot access to the requested resource if you are requesting another user.
