### PR TITLE
Add a 'scope' parameter to provide runtime query configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,5 +301,18 @@ end
 
 Note: If both an `:unauthorized_handler` and a `:not_found_handler` are specified for `load_and_authorize_resource`, and the request meets the criteria for both, the `:unauthorized_handler` will be called first.
 
+### Handling situation where the id is not enough to load a resource
+
+If you need to alter your load_resource queries beyond just pulling the id, you can set a scope parameter in your canary config that will accept the query, and the `conn`. Here's an example of how it might be used to set a table prefix (for multi-tenant solutions)
+
+```elixir
+config :canary, scope: fn(queryable, %{assigns: %{tenant: tenant}}) do
+  queryable
+  |> Ecto.Queryable.to_query
+  |> Map.put(:prefix, tenant)
+end
+```
+
+
 ## License
 MIT License. Copyright 2016 Chris Kelly.


### PR DESCRIPTION
I haven't had a chance to put the specs into this yet, but they are forthcoming. I just wanted to push this up now to begin the conversation on whether this is the right direction, particularly in light of the other PR that also seems to have to do with fetching resources.  This was all the configuration I needed for my project (multi-tenant database, so I had to set the prefix on the queries).

That said, I'm not sure that directly using a Repo is something that canary ought to be doing at its core. Perhaps there could be swappable strategies that could be chosen instead?  Just a thought.
