### PR TITLE
Idiomatic elixir, use credo

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,129 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        included: ["lib/", "src/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
+      },
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      requires: [],
+      #
+      # Credo automatically checks for updates, like e.g. Hex does.
+      # You can disable this behaviour below:
+      check_for_updates: true,
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      strict: false,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        {Credo.Check.Consistency.ExceptionNames},
+        {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse},
+        {Credo.Check.Consistency.ParameterPatternMatching},
+        {Credo.Check.Consistency.SpaceAroundOperators},
+        {Credo.Check.Consistency.SpaceInParentheses},
+        {Credo.Check.Consistency.TabsOrSpaces},
+
+        # For some checks, like AliasUsage, you can only customize the priority
+        # Priority values are: `low, normal, high, higher`
+        {Credo.Check.Design.AliasUsage, priority: :low},
+
+        # For others you can set parameters
+
+        # If you don't want the `setup` and `test` macro calls in ExUnit tests
+        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagFIXME},
+
+        {Credo.Check.Readability.FunctionNames},
+        {Credo.Check.Readability.LargeNumbers},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.ModuleAttributeNames},
+        {Credo.Check.Readability.ModuleDoc},
+        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.NoParenthesesWhenZeroArity},
+        {Credo.Check.Readability.ParenthesesInCondition},
+        {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.PreferImplicitTry},
+        {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Readability.StringSigils},
+        {Credo.Check.Readability.TrailingBlankLine},
+        {Credo.Check.Readability.TrailingWhiteSpace},
+        {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Refactor.DoubleBooleanNegation},
+
+        # {Credo.Check.Refactor.CaseTrivialMatches}, # deprecated in 0.4.0
+        {Credo.Check.Refactor.ABCSize},
+        {Credo.Check.Refactor.CondStatements},
+        {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.MatchInCondition},
+        {Credo.Check.Refactor.NegatedConditionsInUnless},
+        {Credo.Check.Refactor.NegatedConditionsWithElse},
+        {Credo.Check.Refactor.Nesting},
+        {Credo.Check.Refactor.PipeChainStart, false},
+        {Credo.Check.Refactor.UnlessWithElse},
+        {Credo.Check.Refactor.VariableRebinding},
+
+        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.IExPry},
+        {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.NameRedeclarationByAssignment},
+        {Credo.Check.Warning.NameRedeclarationByCase},
+        {Credo.Check.Warning.NameRedeclarationByDef},
+        {Credo.Check.Warning.NameRedeclarationByFn},
+        {Credo.Check.Warning.OperationOnSameValues},
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedFileOperation},
+        {Credo.Check.Warning.UnusedKeywordOperation},
+        {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedPathOperation},
+        {Credo.Check.Warning.UnusedRegexOperation},
+        {Credo.Check.Warning.UnusedStringOperation},
+        {Credo.Check.Warning.UnusedTupleOperation},
+
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: elixir
 elixir:
     - 1.3.0
+script: mix test && mix credo

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -87,30 +87,32 @@ defmodule Canary.Plugs do
   ```
   """
   def load_resource(conn, opts) do
-    conn
-    |> action_valid?(opts)
-    |> case do
-      true  -> _load_resource(conn, opts) |> handle_not_found(opts)
-      false -> conn
+    if action_valid?(conn, opts) do
+      conn
+      |> do_load_resource(opts)
+      |> handle_not_found(opts)
+    else
+      conn
     end
   end
 
-  defp _load_resource(conn, opts) do
+  defp do_load_resource(conn, opts) do
     action = get_action(conn)
     is_persisted = persisted?(opts)
 
-    loaded_resource = cond do
-      is_persisted ->
-        fetch_resource(conn, opts)
-      action == :index ->
-        fetch_all(conn, opts)
-      action in [:new, :create] ->
-        nil
-      true ->
-        fetch_resource(conn, opts)
-    end
+    loaded_resource =
+      cond do
+        is_persisted ->
+          fetch_resource(conn, opts)
+        action == :index ->
+          fetch_all(conn, opts)
+        action in [:new, :create] ->
+          nil
+        true ->
+          fetch_resource(conn, opts)
+      end
 
-    Plug.Conn.assign(conn, resource_name(conn, opts), loaded_resource)
+    Plug.Conn.assign(conn, get_resource_name(conn, opts), loaded_resource)
   end
 
   @doc """
@@ -180,20 +182,24 @@ defmodule Canary.Plugs do
   ```
   """
   def authorize_resource(conn, opts) do
-    conn
-    |> action_valid?(opts)
-    |> case do
-      true  -> _authorize_resource(conn, opts) |> handle_unauthorized(opts)
-      false -> conn
+    if action_valid?(conn, opts) do
+      do_authorize_resource(conn, opts) |> handle_unauthorized(opts)
+    else
+      conn
     end
   end
 
-  defp _authorize_resource(conn, opts) do
+  defp do_authorize_resource(conn, opts) do
     current_user_name = opts[:current_user] || Application.get_env(:canary, :current_user, :current_user)
     current_user = Map.fetch! conn.assigns, current_user_name
     action = get_action(conn)
     is_persisted = persisted?(opts)
-    non_id_actions = if opts[:non_id_actions], do: Enum.concat([:index, :new, :create], opts[:non_id_actions]), else: [:index, :new, :create]
+    non_id_actions =
+      if opts[:non_id_actions] do
+        Enum.concat([:index, :new, :create], opts[:non_id_actions])
+      else
+        [:index, :new, :create]
+      end
 
     resource = cond do
       is_persisted ->
@@ -252,15 +258,14 @@ defmodule Canary.Plugs do
   ```
   """
   def load_and_authorize_resource(conn, opts) do
-    conn
-    |> action_valid?(opts)
-    |> case do
-      true  -> _load_and_authorize_resource(conn, opts)
-      false -> conn
+    if action_valid?(conn, opts) do
+      do_load_and_authorize_resource(conn, opts)
+    else
+      conn
     end
   end
 
-  defp _load_and_authorize_resource(conn, opts) do
+  defp do_load_and_authorize_resource(conn, opts) do
     conn
     |> Map.put(:skip_canary_handler, true) # skip not_found_handler so auth handler can catch first if needed
     |> load_resource(opts)
@@ -277,19 +282,16 @@ defmodule Canary.Plugs do
   defp purge_resource_if_unauthorized(conn = %{assigns: %{authorized: true}}, _opts),
     do: conn
   defp purge_resource_if_unauthorized(conn = %{assigns: %{authorized: false}}, opts),
-    do: Plug.Conn.assign(conn, resource_name(conn, opts), nil)
+    do: Plug.Conn.assign(conn, get_resource_name(conn, opts), nil)
 
   defp fetch_resource(conn, opts) do
     repo = Application.get_env(:canary, :repo)
 
     field_name = (opts[:id_field] || "id")
 
-    get_map_args = %{field_name => get_resource_id(conn, opts)}
-    get_map_args = (for {key, val} <- get_map_args, into: %{}, do: {String.to_atom(key), val})
+    get_map_args = %{String.to_atom(field_name) => get_resource_id(conn, opts)}
 
-    conn.assigns
-    |> Map.fetch(resource_name(conn, opts)) # check if a resource is already loaded at the key
-    |> case do
+    case Map.fetch(conn.assigns, get_resource_name(conn, opts)) do
       :error ->
         repo.get_by(opts[:model], get_map_args)
         |> preload_if_needed(repo, opts)
@@ -297,12 +299,12 @@ defmodule Canary.Plugs do
         repo.get_by(opts[:model], get_map_args)
         |> preload_if_needed(repo, opts)
       {:ok, resource} ->
-        case (resource.__struct__ == opts[:model]) do
-          true  -> # A resource of the type passed as opts[:model] is already loaded; do not clobber it
-            resource
-          false ->
-            repo.get_by(opts[:model], get_map_args)
-            |> preload_if_needed(repo, opts)
+        if resource.__struct__ == opts[:model] do
+          resource # A resource of the type passed as opts[:model] is already loaded; do not clobber it
+        else
+          opts[:model]
+          |> repo.get_by(get_map_args)
+          |> preload_if_needed(repo, opts)
         end
     end
   end
@@ -310,17 +312,16 @@ defmodule Canary.Plugs do
   defp fetch_all(conn, opts) do
     repo = Application.get_env(:canary, :repo)
 
-    conn.assigns
-    |> Map.fetch(resource_name(conn, opts))
-    |> case do # check if a resource is already loaded at the key
+    resource_name = get_resource_name(conn, opts)
+
+    case Map.fetch(conn.assigns, resource_name) do # check if a resource is already loaded at the key
       :error ->
         from(m in opts[:model]) |> select([m], m) |> repo.all |> preload_if_needed(repo, opts)
       {:ok, resources} ->
-        case (Enum.at(resources, 0).__struct__ == opts[:model]) do
-          true  ->
-            resources
-          false ->
-            from(m in opts[:model]) |> select([m], m) |> repo.all |> preload_if_needed(repo, opts)
+        if Enum.at(resources, 0).__struct__ == opts[:model] do
+          resources
+        else
+          from(m in opts[:model]) |> select([m], m) |> repo.all |> preload_if_needed(repo, opts)
         end
     end
   end
@@ -335,9 +336,7 @@ defmodule Canary.Plugs do
   end
 
   defp get_action(conn) do
-    conn.assigns
-    |> Map.fetch(:canary_action)
-    |> case do
+    case Map.fetch(conn.assigns, :canary_action) do
       {:ok, action} -> action
       _             -> conn.private.phoenix_action
     end
@@ -346,20 +345,20 @@ defmodule Canary.Plugs do
   defp action_exempt?(conn, opts) do
     action = get_action(conn)
 
-    (is_list(opts[:except]) && action in opts[:except])
-    |> case do
-      true  -> true
-      false -> action == opts[:except]
+    if is_list(opts[:except]) && action in opts[:except] do
+      true
+    else
+      action == opts[:except]
     end
   end
 
   defp action_included?(conn, opts) do
     action = get_action(conn)
 
-    (is_list(opts[:only]) && action in opts[:only])
-    |> case do
-      true  -> true
-      false -> action == opts[:only]
+    if is_list(opts[:only]) && action in opts[:only] do
+      true
+    else
+      action == opts[:only]
     end
   end
 
@@ -380,15 +379,15 @@ defmodule Canary.Plugs do
     !!Keyword.get(opts, :persisted, false)
   end
 
-  defp resource_name(conn, opts) do
+  defp get_resource_name(conn, opts) do
     case opts[:as] do
       nil ->
         opts[:model]
-        |> Module.split
-        |> List.last
-        |> Macro.underscore
+        |> Module.split()
+        |> List.last()
+        |> Macro.underscore()
         |> pluralize_if_needed(conn, opts)
-        |> String.to_atom
+        |> String.to_atom()
       as -> as
     end
   end
@@ -414,26 +413,31 @@ defmodule Canary.Plugs do
     end
   end
 
-  defp handle_unauthorized(conn = %{skip_canary_handler: true}, _opts),
+  defp handle_unauthorized(%{skip_canary_handler: true} = conn, _opts),
     do: conn
-  defp handle_unauthorized(conn = %{assigns: %{authorized: true}}, _opts),
+  defp handle_unauthorized(%{assigns: %{authorized: true}} = conn, _opts),
     do: conn
-  defp handle_unauthorized(conn = %{assigns: %{authorized: false}}, opts),
+  defp handle_unauthorized(%{assigns: %{authorized: false}} = conn, opts),
     do: apply_error_handler(conn, :unauthorized_handler, opts)
 
-  defp handle_not_found(conn = %{skip_canary_handler: true}, _opts) do
+  defp handle_not_found(%{skip_canary_handler: true} = conn, _opts) do
     conn
   end
 
   defp handle_not_found(conn, opts) do
     action = get_action(conn)
-    non_id_actions = if opts[:non_id_actions], do: Enum.concat([:index, :new, :create], opts[:non_id_actions]), else: [:index, :new, :create]
+    non_id_actions =
+      if opts[:non_id_actions] do
+        Enum.concat([:index, :new, :create], opts[:non_id_actions])
+      else
+        [:index, :new, :create]
+      end
+    resource_name = Map.get(conn.assigns, get_resource_name(conn, opts))
 
-    case is_nil(Map.get(conn.assigns, resource_name(conn, opts)))
-      and not action in non_id_actions do
-
-      true -> apply_error_handler(conn, :not_found_handler, opts)
-      false -> conn
+    if is_nil(resource_name) and not action in non_id_actions do
+      apply_error_handler(conn, :not_found_handler, opts)
+    else
+      conn
     end
   end
 

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -276,18 +276,18 @@ defmodule Canary.Plugs do
   end
 
   # Only try to handle 404 if the response has not been sent during authorization handling
-  defp maybe_handle_not_found(conn = %{state: :sent}, _opts), do: conn
+  defp maybe_handle_not_found(%{state: :sent} = conn, _opts), do: conn
   defp maybe_handle_not_found(conn, opts), do: handle_not_found(conn, opts)
 
-  defp purge_resource_if_unauthorized(conn = %{assigns: %{authorized: true}}, _opts),
+  defp purge_resource_if_unauthorized(%{assigns: %{authorized: true}} = conn, _opts),
     do: conn
-  defp purge_resource_if_unauthorized(conn = %{assigns: %{authorized: false}}, opts),
+  defp purge_resource_if_unauthorized(%{assigns: %{authorized: false}} = conn, opts),
     do: Plug.Conn.assign(conn, get_resource_name(conn, opts), nil)
 
   defp fetch_resource(conn, opts) do
     repo = Application.get_env(:canary, :repo)
 
-    field_name = (opts[:id_field] || "id")
+    field_name = Keyword.get(opts, :id_field, "id")
 
     get_map_args = %{String.to_atom(field_name) => get_resource_id(conn, opts)}
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,14 +5,14 @@ defmodule Canary.Mixfile do
     [app: :canary,
      version: "1.1.0",
      elixir: "~> 1.2",
-     package: package,
+     package: package(),
      description: """
      An authorization library to restrict what resources the current user is
      allowed to access, and load those resources for you.
      """,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      consolidate_protocols: false,
      docs: [extras: ["README.md"]]]
   end
@@ -34,7 +34,9 @@ defmodule Canary.Mixfile do
      {:plug, "~> 1.0"},
      {:ex_doc, "~> 0.7", only: :dev},
      {:earmark, ">= 0.0.0", only: :dev},
-     {:mock, ">= 0.0.0", only: :test}
+     {:mock, ">= 0.0.0", only: :test},
+
+     {:credo, "~> 0.5", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"canada": {:hex, :canada, "1.0.1", "da96d0ff101a0c2a6cc7b07d92b8884ff6508f058781d3679999416feacf41c5", [:mix], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "canada": {:hex, :canada, "1.0.1", "da96d0ff101a0c2a6cc7b07d92b8884ff6508f058781d3679999416feacf41c5", [:mix], []},
+  "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.2", "b02331c1f20bbe944dbd33c8ecd8f1ccffecc02e344c4471a891baf3a25f5406", [:mix], [{:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
 %{"canada": {:hex, :canada, "1.0.1", "da96d0ff101a0c2a6cc7b07d92b8884ff6508f058781d3679999416feacf41c5", [:mix], []},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ecto": {:hex, :ecto, "2.0.2", "b02331c1f20bbe944dbd33c8ecd8f1ccffecc02e344c4471a891baf3a25f5406", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}]},
+  "ecto": {:hex, :ecto, "2.0.2", "b02331c1f20bbe944dbd33c8ecd8f1ccffecc02e344c4471a891baf3a25f5406", [:mix], [{:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "mock": {:hex, :mock, "0.1.3", "657937b03f88fce89b3f7d6becc9f1ec1ac19c71081aeb32117db9bc4d9b3980", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
   "plug": {:hex, :plug, "1.1.5", "de5645c18170415a72b18cc3d215c05321ddecac27a15acb923742156e98278b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}


### PR DESCRIPTION
I've been using canary in a side project of mine, and noticed that the codebase could be cleaned up a bit in terms of idiomatic elixir code.

Made several changes to simplify code, and make it more idiomatic.

As far as credo goes, disabled PipeChainStart and Specs