### PR TITLE
Introduces authorize_controller functionality

### DIFF
--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -130,7 +130,7 @@ defmodule Canary.Plugs do
     2) :canary_controller in conn.assigns
   In case you are not using phoenix, make sure you set the controller name in the conn.assigns
   Note that in case neither of :phoenix_controller or :canary_controller are found the requested
-    authorization won't necessarily fails, rather it will trigger a can? function with user = nil
+    authorization won't necessarily fail, rather it will trigger a can? function with user assinged as nil
 
   If authorization succeeds, sets `conn.assigns.authorized` to true.
 

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -130,7 +130,7 @@ defmodule Canary.Plugs do
     2) :canary_controller in conn.assigns
   In case you are not using phoenix, make sure you set the controller name in the conn.assigns
   Note that in case neither of :phoenix_controller or :canary_controller are found the requested
-    authorization will automatically fails
+    authorization won't necessarily fails, rather it will trigger a can? function with user = nil
 
   If authorization succeeds, sets `conn.assigns.authorized` to true.
 

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -181,14 +181,10 @@ defmodule Canary.Plugs do
   plug :load_resource, model: Post, id_name: "slug", id_field: "slug", only: [:show], persisted: true
   ```
   """
-  def authorize_controller(%{assigns: %{current_user: nil}} = conn, opts) do
-    conn
-    |> Plug.Conn.assign(:authorized, false)
-    |> handle_unauthorized(opts)
-  end
-  def authorize_controller(%{assigns: %{current_user: user},
-                             private: %{phoenix_controller: controller}} = conn, opts) do
-    current_user_name = opts[:current_user] || Application.get_env(:canary, :current_user, :current_user)
+  def authorize_controller(conn, opts) do
+    controller = conn.assigns[:canary_controller] || conn.private[:phoenix_controller]
+    current_user_name = opts[:current_user] ||
+      Application.get_env(:canary, :current_user, :current_user)
     current_user = Map.fetch! conn.assigns, current_user_name
     action = get_action(conn)
 
@@ -200,7 +196,6 @@ defmodule Canary.Plugs do
       conn
     end
   end
-  def authorize_controller(conn, _), do: Plug.Conn.assign(conn, :authorized, true)
 
   def authorize_resource(conn, opts) do
     if action_valid?(conn, opts) do

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -63,6 +63,7 @@ end
 
 defimpl Canada.Can, for: Atom do
   def can?(nil, :create, Post), do: false
+  def can?(nil, :create, Myproject.SampleController), do: false
 end
 
 defmodule Helpers do
@@ -1612,12 +1613,12 @@ defmodule PlugTest do
     assert authorize_controller(conn, opts) == expected
 
     # when the current user can access the given resource
-    # and the action is specified in conn.assigns.canary_action
+    # and the action and controller are specified in conn.assigns.canary_action
     params = %{"id" => 1}
     conn = conn(
       %Plug.Conn{
         private: %{},
-        assigns: %{current_user: %User{id: 1}, canary_action: :show}
+        assigns: %{current_user: %User{id: 1}, canary_action: :show, canary_controller: Myproject.SampleController}
       },
       :get,
       "/posts/1",


### PR DESCRIPTION
send calling controller to the canada.can? function instead of model

This way a user can be authorized based on the action And the controller the action is called from