### PR TITLE
Do not run both handlers on load_and_authorize if conn was halted

### DIFF
--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -337,7 +337,8 @@ defmodule Canary.Plugs do
     |> purge_resource_if_unauthorized(opts)
   end
 
-  # Only try to handle 404 if the response has not been sent during authorization handling
+  # Only try to handle 404 if the response has not been halted or sent during authorization handling
+  defp maybe_handle_not_found(%{halted: true} = conn, _opts), do: conn
   defp maybe_handle_not_found(%{state: :sent} = conn, _opts), do: conn
   defp maybe_handle_not_found(conn, opts), do: handle_not_found(conn, opts)
 


### PR DESCRIPTION
While your own readme uses `halt/1` as the last function called in an error helper example, calling `halt` in the helpers will _not_ properly stop the calling of both error helpers in the case of `load_and_authorize_resource/2` because it's only checking for sent connections. 

Having it check if the conn has been halted after `handle_unauthorized/2` makes things behave in a more intuitively Pluggy way.

