### PR TITLE
skip non_id_actions in handle_not_found when opts[:persisted] == true

### DIFF
--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -488,12 +488,16 @@ defmodule Canary.Plugs do
 
   defp handle_not_found(conn, opts) do
     action = get_action(conn)
-    non_id_actions =
+    non_id_actions = unless opts[:persisted] do
+      default_non_id_actions = [:index, :new, :create]
       if opts[:non_id_actions] do
-        Enum.concat([:index, :new, :create], opts[:non_id_actions])
+        Enum.concat(default_non_id_actions, opts[:non_id_actions])
       else
-        [:index, :new, :create]
+        default_non_id_actions
       end
+    else
+      []
+    end
     resource_name = Map.get(conn.assigns, get_resource_name(conn, opts))
 
     if is_nil(resource_name) and not action in non_id_actions do


### PR DESCRIPTION
So this PR is mostly to start a conversation, this fixes an issue (that affects me at least), which is when using `load_and_authorize_resource` with `persisted: true` in order to authorize a parent resource of the currently being targeted resource when in one of the `non_id_actions` it will not error, and if the controller action or template you assume that parent resource will be available then it will break, to me it makes sense to use the `:not_found_handler`.

This PR skips the `non_id_actions` when `opts[:persisted] == true`, if this problem is not obvious to everybody else perhaps it needs an extra parameter or perhaps it doesn't make sense in upstream at all.